### PR TITLE
Update geth process command for 1.8.15+

### DIFF
--- a/docs/getting-started/install-cent-node.md
+++ b/docs/getting-started/install-cent-node.md
@@ -74,7 +74,7 @@ Rinkeby is a testnet
 Start the `geth` process: 
 
   ```bash
-  $ geth --rinkeby --light --rpc --rpcapi db,eth,net,web3,txpool --ws \
+  $ geth --rinkeby --syncmode light --rpc --rpcapi db,eth,net,web3,txpool --ws \
   --wsorigins "*" --wsapi db,eth,net,web3,txpool > /tmp/geth.log 2>&1 &
    ```
 


### PR DESCRIPTION
Update the geth process command to use `syncmode` instead as in geth 1.8.15 the `--light` and `--fast` CLI flags have been deprecated as per https://github.com/ethereum/go-ethereum/pull/17402