### PR TITLE
Bump swagger version to 0.0.2

### DIFF
--- a/docs/further-reading/more-info.md
+++ b/docs/further-reading/more-info.md
@@ -3,7 +3,7 @@ id: more-info
 title: Further Details
 ---
 
-For more information on the API calls, see [Centrifuge Node API documentation](https://app.swaggerhub.com/apis-docs/centrifuge.io/cent-node/0.0.1).
+For more information on the API calls, see [Centrifuge Node API documentation](https://app.swaggerhub.com/apis-docs/centrifuge.io/cent-node/0.0.2).
 
 For a sample `config.yaml` file, see [Centrifuge `config.yaml` file](https://github.com/centrifuge/go-centrifuge/blob/develop/build/configs/default_config.yaml). 
 


### PR DESCRIPTION
Link to version 0.0.1 is 404-ing