### PR TITLE
Fix subkey command

### DIFF
--- a/docs/chain/get-started/run-node.md
+++ b/docs/chain/get-started/run-node.md
@@ -22,7 +22,7 @@ Running a bare metal setup requires you to compile centrifuge chain from source,
 ## Run your node in a Docker Container
 
 1. Ensure you have [docker](https://docs.docker.com/install/) as well as [subkey](https://substrate.dev/docs/en/development/tools/subkey#installation) installed. Use `subkey` version `v2.0.0-alpha3`.
-2. Generate a new key pair with subkey that will be used as your node-key: `subkey generate`. Make sure you save the output in a safe place. For mainnet keys use network flag: `subkey generate -n centrifuge`  
+2. Generate a new key pair with subkey that will be used as your node-key: `subkey generate`. Make sure you save the output in a safe place. For mainnet keys use network flag: `subkey -n centrifuge generate`  
 3. Start your node by running the following, where {name} is the name that will show up in Polkadot Telemetry and {node-key} is the private key you just generated (without the `0x` prefix). Note that we do expose RPC and WS ports here for simplicity – these ports should not be exposed in a production grade setup.
 
 a) Amber: 


### PR DESCRIPTION
Minor fix on the `subkey` command that was throwing the following error:

```shell
error: Found argument '-n' which wasn't expected, or isn't valid in this context
```