### PR TITLE
Fix minor typo in rate exponent

### DIFF
--- a/docs/learn/interest-rate-methodology/index.md
+++ b/docs/learn/interest-rate-methodology/index.md
@@ -59,7 +59,7 @@ $$
 ### Calculate Debt
 
 $$
-D = P * rate^t
+D = P * rate^n
 $$
 
 The debt can be calculated by multipling the principial $P$ with $rate$ to the power of $n$. The variable $n$ represents the time passed in seconds since the loan has been borrowed.


### PR DESCRIPTION
This PR fixes a typo in Calculate Debt paragraph of Interest Rate Methodology page.